### PR TITLE
Neater instance identifier handling

### DIFF
--- a/handler/shared.ts
+++ b/handler/shared.ts
@@ -26,7 +26,7 @@ export interface AuroraSnapshotHandlerOptions {
     sources: Array<AuroraSnapshotSourceSelector>;
     aggregation?: AuroraSnapshotSourceAggregation;
     target: AuroraSnapshotTarget;
-    instanceIdentifier?: string;
+    instanceIdentifier: string;
 }
 
 export const toEnv = (source: AuroraSnapshotSourceSelector, index: number): Record<string, string> => {
@@ -113,6 +113,8 @@ export const allToEnv = (options: AuroraSnapshotHandlerOptions): Record<string, 
 
     const env = Object.assign({}, ...envParts);
 
+    env['INSTANCE_IDENTIFIER'] = options.instanceIdentifier;
+
     if (options.aggregation) {
         if (typeof options.aggregation.latestCountPerCluster !== 'undefined') {
             env['AGGREGATION_LATEST_COUNT_PER_CLUSTER'] = `${options.aggregation.latestCountPerCluster}`;
@@ -150,6 +152,8 @@ export const allFromEnv = (env: Record<string, string | undefined>): AuroraSnaps
         index++;
     }
 
+    const instanceIdentifier = env['INSTANCE_IDENTIFIER'] ?? '';
+
     const target: AuroraSnapshotTarget = {
         regions: env['TARGET_REGIONS'] ? env['TARGET_REGIONS'].split(',') : [],
     };
@@ -181,6 +185,7 @@ export const allFromEnv = (env: Record<string, string | undefined>): AuroraSnaps
     const options: AuroraSnapshotHandlerOptions = {
         sources,
         target,
+        instanceIdentifier,
     };
 
     const rawLatestCountPerCluster = env['AGGREGATION_LATEST_COUNT_PER_CLUSTER'];

--- a/handler/utils.ts
+++ b/handler/utils.ts
@@ -1,3 +1,6 @@
+export type PickRequired<T, Keys extends keyof T> = Required<Pick<T, Keys>> & Omit<T, Keys>;
+export type PickPartial<T, Keys extends keyof T> = Partial<Pick<T, Keys>> & Omit<T, Keys>;
+
 export const fromAwsTags = (awsTags: AWS.RDS.Types.TagList | undefined): Record<string, string> => {
     const tags: Record<string, string> = {};
     for (const awsTag of awsTags || []) {
@@ -31,4 +34,10 @@ export const isArrayOfStrings = (obj: unknown): obj is Array<string> => {
 
 export const hasKey = <T, K extends PropertyKey>(obj: unknown, prop: K): obj is T & Record<K, unknown> => {
     return typeof obj === 'object' && !!obj && Object.prototype.hasOwnProperty.call(obj, prop);
+};
+
+export const objOf = (key: string, value: string): Record<string, string> => {
+    const obj: Record<string, string> = {};
+    obj[key] = value;
+    return obj;
 };

--- a/test/cdk.test.ts
+++ b/test/cdk.test.ts
@@ -26,6 +26,7 @@ describe('construct', () => {
                     Variables: {
                         SOURCE_0_DB_CLUSTER_IDENTIFIER: 'myidentifier',
                         TARGET_REGIONS: 'eu-west-1,eu-central-1',
+                        INSTANCE_IDENTIFIER: 'default',
                     },
                 },
             }),

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -214,6 +214,7 @@ describe('filterSnapshotsForDeletionPolicy', () => {
         arn: 'olderA',
         clusterIdentifier: 'A',
         createdAtTime: new Date('2021-01-01'),
+        justRemoveTag: false,
     };
 
     const oldA = {
@@ -221,6 +222,7 @@ describe('filterSnapshotsForDeletionPolicy', () => {
         arn: 'oldA',
         clusterIdentifier: 'A',
         createdAtTime: new Date('2021-02-01'),
+        justRemoveTag: false,
     };
 
     const newerA = {
@@ -228,6 +230,7 @@ describe('filterSnapshotsForDeletionPolicy', () => {
         arn: 'newerA',
         clusterIdentifier: 'A',
         createdAtTime: new Date('2021-03-01'),
+        justRemoveTag: false,
     };
 
     const olderB = {
@@ -235,6 +238,7 @@ describe('filterSnapshotsForDeletionPolicy', () => {
         arn: 'olderB',
         clusterIdentifier: 'B',
         createdAtTime: new Date('2021-01-01'),
+        justRemoveTag: false,
     };
 
     const oldB = {
@@ -242,6 +246,7 @@ describe('filterSnapshotsForDeletionPolicy', () => {
         arn: 'oldB',
         clusterIdentifier: 'B',
         createdAtTime: new Date('2021-02-01'),
+        justRemoveTag: false,
     };
 
     const newerB = {
@@ -249,6 +254,7 @@ describe('filterSnapshotsForDeletionPolicy', () => {
         arn: 'newerB',
         clusterIdentifier: 'B',
         createdAtTime: new Date('2021-03-01'),
+        justRemoveTag: false,
     };
 
     test('deletion policy latest count per cluster', () => {
@@ -432,6 +438,7 @@ describe('copySnapshotToRegion', () => {
             },
             sourceRegion: 'eu-west-1',
             targetRegion: 'eu-west-2',
+            instanceIdentifier: 'instanceId',
         });
 
         // THEN
@@ -449,7 +456,7 @@ describe('copySnapshotToRegion', () => {
 
             Tags: [
                 {
-                    Key: 'aurora-snapshot-copier-cdk/CopiedBy',
+                    Key: 'aurora-snapshot-copier-cdk/CopiedBy/instanceId',
                     Value: 'aurora-snapshot-copier-cdk',
                 },
                 {
@@ -591,7 +598,7 @@ describe('copySnapshotsToRegion', () => {
                 },
             ],
             'eu-west-1',
-            undefined,
+            'instanceId',
         );
 
         expect(copyDBClusterSnapshotSpy.callCount).toEqual(2);
@@ -621,7 +628,7 @@ describe('handleSnapshotDeletion', () => {
                         SnapshotCreateTime: new Date(new Date().getTime() - 24 * HOUR_IN_MILLIS),
                         TagList: [
                             {
-                                Key: 'aurora-snapshot-copier-cdk/CopiedBy',
+                                Key: 'aurora-snapshot-copier-cdk/CopiedBy/instanceId',
                                 Value: 'aurora-snapshot-copier-cdk',
                             },
                         ],
@@ -638,7 +645,7 @@ describe('handleSnapshotDeletion', () => {
                 apply: true,
             },
             'eu-west-2',
-            undefined,
+            'instanceId',
         );
 
         expect(deleteDBClusterSnapshotSpy.callCount).toEqual(1);
@@ -669,7 +676,7 @@ describe('copySnapshots', () => {
             {
                 regions: ['eu-west-1', 'eu-west-2'],
             },
-            undefined,
+            'instanceId',
         );
 
         expect(mockCopySnapshotsToRegion.callCount).toEqual(2);
@@ -700,7 +707,7 @@ describe('deleteSnapshots', () => {
             {
                 regions: ['eu-west-1', 'eu-west-2'],
             },
-            undefined,
+            'instanceId',
         );
 
         expect(mockHandleSnapshotDeletion.callCount).toEqual(2);
@@ -718,6 +725,7 @@ describe('handler', () => {
             target: {
                 regions: ['eu-west-1'],
             },
+            instanceIdentifier: 'instanceId',
         }));
 
         jest.spyOn(shared, 'allFromEnv').mockImplementation(mockAllFromEnv);
@@ -757,7 +765,7 @@ describe('handler', () => {
             {
                 regions: ['eu-west-1'],
             },
-            undefined,
+            'instanceId',
         ]);
     });
 });

--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -94,6 +94,7 @@ describe('allToEnv/allFromEnv', () => {
                         apply: true,
                     },
                 },
+                instanceIdentifier: 'instanceId',
             }),
         ).toEqual({
             SOURCE_0_DB_CLUSTER_IDENTIFIER: 'mysourcedbclusteridentifier_1',
@@ -109,6 +110,7 @@ describe('allToEnv/allFromEnv', () => {
             TARGET_DELETION_POLICY_APPLY: '1',
             TARGET_DELETION_POLICY_KEEP_CREATED_IN_THE_LAST_SECONDS: '2678400',
             TARGET_DELETION_POLICY_KEEP_LATEST_COUNT_PER_DB_CLUSTER_IDENTIFIER: '5',
+            INSTANCE_IDENTIFIER: 'instanceId',
         });
     });
 
@@ -128,6 +130,7 @@ describe('allToEnv/allFromEnv', () => {
                 TARGET_DELETION_POLICY_APPLY: '1',
                 TARGET_DELETION_POLICY_KEEP_CREATED_IN_THE_LAST_SECONDS: '2678400',
                 TARGET_DELETION_POLICY_KEEP_LATEST_COUNT_PER_DB_CLUSTER_IDENTIFIER: '5',
+                INSTANCE_IDENTIFIER: 'instanceId',
             }),
         ).toEqual({
             sources: [
@@ -151,6 +154,7 @@ describe('allToEnv/allFromEnv', () => {
                     apply: true,
                 },
             },
+            instanceIdentifier: 'instanceId',
         });
     });
 
@@ -177,6 +181,7 @@ describe('allToEnv/allFromEnv', () => {
                     apply: true,
                 },
             },
+            instanceIdentifier: 'instanceId',
         };
 
         expect(allFromEnv(allToEnv(options))).toEqual(options);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { fromAwsTags, kmsKeyIdOrArnToId, isArrayOfStrings, hasKey } from '../handler/utils';
+import { fromAwsTags, kmsKeyIdOrArnToId, isArrayOfStrings, hasKey, objOf } from '../handler/utils';
 
 describe('fromAwsTags', () => {
     test('empty', () => {
@@ -106,5 +106,13 @@ describe('hasKey', () => {
 
     test('is null', () => {
         expect(hasKey(null, 'foo')).toEqual(false);
+    });
+});
+
+describe('objOf', () => {
+    test('simple', () => {
+        expect(objOf('foo', 'bar')).toEqual({
+            foo: 'bar',
+        });
     });
 });


### PR DESCRIPTION
The idea here being that multiple instances of the copier could exist in the same account, copying the same snapshots. Then when deleting, only delete if the only remaining tag is for the current instance, otherwise just remove the tag for the current instance.